### PR TITLE
fix capitalization of sirupsen

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -6,7 +6,7 @@ package evloghook
 import (
 	"golang.org/x/sys/windows/svc/eventlog"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const levels = eventlog.Error | eventlog.Warning | eventlog.Info


### PR DESCRIPTION
apparently most things capitalize this as sirupse..

this commit is slightly stolen from upstream:
https://github.com/aadidenko/evloghook/commit/1584bba3e706fd36a08b319c07433aac9ced0827
but without the added benefit of changing every line.